### PR TITLE
Dockerizing Project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.dockerignore
+.git
+.gitignore
+Dockerfile
+README.md
+core-server
+models
+restapi
+!restapi/configure_core.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:alpine AS build
+
+WORKDIR /go/src/app
+
+COPY . .
+
+COPY --from=quay.io/goswagger/swagger /usr/bin/swagger /usr/bin/swagger
+
+RUN swagger generate server --exclude-spec --name=core --spec=./swagger/swagger.yaml
+
+RUN go get -d -v ./...
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/app ./cmd/core-server
+
+FROM alpine:latest AS alpine
+
+RUN apk --no-cache add ca-certificates
+
+FROM scratch
+
+COPY --from=build /go/bin/app /app
+
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
This PR adds a **Dockerfile** and a supporting **.dockerignore** file.  The **Dockerfile** lays out a multistage build.  The stages include:
1. build
2. alpine
3. *unnamed*

In the **build** stage, the **swagger** tool is run to generate the server code.  Then, the **go get** and  **go build** tools are run to fetch the dependencies and build the binary for the service.
In the **alpine** stage, the **ca-certificates** package is installed.  This package provides the **/etc/ssl/certs/ca-certificates.crt** file, which contains all of the publicly trusted Certificate Authorities' certificates.  Adding this file to the final image is needed in order to establish outbound TLS connections.
In the final *unnamed* stage, the binary built in the **build** stage is copied and so is the **ca-certificates.crt** file.

The **.dockerignore** file is used to exclude unnecessary files from the build context copied to the Docker daemon.  Most significantly, the generated code residing in the **models** and **restapi** directories.  An exception is made for the **restapi/configure_core.go** file, since it is only generated once and is meant to be modified.

The final Image is based on the special Docker *scratch* image.